### PR TITLE
Feature/modify init py for import

### DIFF
--- a/py_nifcloud/__init__.py
+++ b/py_nifcloud/__init__.py
@@ -1,0 +1,2 @@
+from .computing_client import ComputingClient
+from .nifcloud_client import NifCloudClient

--- a/tests/test_nifcloud_client.py
+++ b/tests/test_nifcloud_client.py
@@ -1,6 +1,6 @@
 # -*- encoding:utf-8 -*-
 import unittest
-from py_nifcloud.computing_client import ComputingClient
+from py_nifcloud import ComputingClient
 
 
 class TestNifCloudClientRequest(unittest.TestCase):


### PR DESCRIPTION
This PR resolves to allow `from py_nifcloud  import hogehoge`

* modify `py_nifcloud/__init__.py`
    * import ComputingClient, NifCloudClient in `__init__.py`