### PR TITLE
Feature/support sig v0 and sig v1

### DIFF
--- a/py_nifcloud/auth.py
+++ b/py_nifcloud/auth.py
@@ -18,7 +18,7 @@ class NifCloudSigV2Auth(SigV2Auth):
     def __init__(self, credentials: Credentials):
         super().__init__(credentials)
 
-    def add_auth(self, request: AWSRequest):
+    def add_auth(self, request: AWSRequest) -> AWSRequest:
         params = request.data
 
         params['AccessKeyId'] = self.credentials.access_key
@@ -37,7 +37,7 @@ class NifCloudSigV1Auth:
     def __init__(self, credentials: Credentials):
         self.credentials = credentials
 
-    def calc_signature(self, params: dict):
+    def calc_signature(self, params: dict) -> str:
         # Signature を含めて string_to_sign を作成する可能性があるため要素を削除
         if "Signature" in params.keys():
             del params["Signature"]
@@ -68,13 +68,13 @@ class NifCloudSigV0Auth:
     def __init__(self, credentials: Credentials):
         self.credentials = credentials
 
-    def calc_signature(self, params: dict):
+    def calc_signature(self, params: dict) -> str:
         string_to_sign = '{action}{timestamp}'.format(action=params["Action"], timestamp=params["Timestamp"])
         lhmac = hmac.new(self.credentials.secret_key.encode('utf-8'), digestmod=hashlib.sha1)
         lhmac.update(string_to_sign.encode('utf-8'))
         return base64.b64encode(lhmac.digest()).strip().decode('utf-8')
 
-    def add_auth(self, request: AWSRequest):
+    def add_auth(self, request: AWSRequest) -> AWSRequest:
         params = request.data
 
         params['AccessKeyId'] = self.credentials.access_key

--- a/py_nifcloud/auth.py
+++ b/py_nifcloud/auth.py
@@ -32,6 +32,37 @@ class NifCloudSigV2Auth(SigV2Auth):
         return request
 
 
+class NifCloudSigV1Auth:
+
+    def __init__(self, credentials: Credentials):
+        self.credentials = credentials
+
+    def calc_signature(self, params: dict):
+        # Signature を含めて string_to_sign を作成する可能性があるため要素を削除
+        if "Signature" in params.keys():
+            del params["Signature"]
+
+        sorted_params = sorted(params.items())
+        string_to_sign = ""
+        for k, v in sorted_params:
+            string_to_sign += "{key}{value}".format(key=k, value=v)
+        lhmac = hmac.new(self.credentials.secret_key.encode('utf-8'), digestmod=hashlib.sha1)
+        lhmac.update(string_to_sign.encode('utf-8'))
+        return base64.b64encode(lhmac.digest()).strip().decode('utf-8')
+
+    def add_auth(self, request: AWSRequest):
+        params = request.data
+        params['AccessKeyId'] = self.credentials.access_key
+        params['SignatureVersion'] = '1'
+        params['SignatureMethod'] = 'HmacSHA1'
+        params['Timestamp'] = time.strftime(ISO8601, time.gmtime())
+        if self.credentials.token:
+            params['SecurityToken'] = self.credentials.token
+        signature = self.calc_signature(params)
+        params['Signature'] = signature
+        return request
+
+
 class NifCloudSigV0Auth:
 
     def __init__(self, credentials: Credentials):

--- a/py_nifcloud/auth.py
+++ b/py_nifcloud/auth.py
@@ -1,5 +1,10 @@
 # -*- encoding:utf-8 -*-
 from botocore.auth import SigV2Auth
+from botocore.awsrequest import AWSRequest
+from botocore.credentials import Credentials
+import hmac
+import hashlib
+import base64
 import logging
 import time
 
@@ -10,10 +15,10 @@ ISO8601 = '%Y-%m-%dT%H:%M:%SZ'
 
 class NifCloudSigV2Auth(SigV2Auth):
 
-    def __init__(self, credentials):
+    def __init__(self, credentials: Credentials):
         super().__init__(credentials)
 
-    def add_auth(self, request):
+    def add_auth(self, request: AWSRequest):
         params = request.data
 
         params['AccessKeyId'] = self.credentials.access_key
@@ -23,5 +28,30 @@ class NifCloudSigV2Auth(SigV2Auth):
         if self.credentials.token:
             params['SecurityToken'] = self.credentials.token
         qs, signature = self.calc_signature(request, params)
+        params['Signature'] = signature
+        return request
+
+
+class NifCloudSigV0Auth:
+
+    def __init__(self, credentials: Credentials):
+        self.credentials = credentials
+
+    def calc_signature(self, params: dict):
+        string_to_sign = '{action}{timestamp}'.format(action=params["Action"], timestamp=params["Timestamp"])
+        lhmac = hmac.new(self.credentials.secret_key.encode('utf-8'), digestmod=hashlib.sha1)
+        lhmac.update(string_to_sign.encode('utf-8'))
+        return base64.b64encode(lhmac.digest()).strip().decode('utf-8')
+
+    def add_auth(self, request: AWSRequest):
+        params = request.data
+
+        params['AccessKeyId'] = self.credentials.access_key
+        params['SignatureVersion'] = '0'
+        params['SignatureMethod'] = 'HmacSHA1'
+        params['Timestamp'] = time.strftime(ISO8601, time.gmtime())
+        if self.credentials.token:
+            params['SecurityToken'] = self.credentials.token
+        signature = self.calc_signature(params)
         params['Signature'] = signature
         return request

--- a/py_nifcloud/nifcloud_client.py
+++ b/py_nifcloud/nifcloud_client.py
@@ -1,7 +1,7 @@
 # -*- encoding:utf-8 -*-
 from botocore.credentials import Credentials
 from botocore.awsrequest import AWSRequest
-from py_nifcloud.auth import NifCloudSigV2Auth
+from py_nifcloud.auth import NifCloudSigV2Auth, NifCloudSigV0Auth
 import os
 import yaml
 import requests
@@ -96,6 +96,8 @@ class NifCloudClient(object):
         signature_version = self._get_signature_version(request)
         if signature_version == "2":
             NifCloudSigV2Auth(self.CREDENTIALS).add_auth(request)
+        elif signature_version == "0":
+            NifCloudSigV0Auth(self.CREDENTIALS).add_auth(request)
             # TODO: 他のバージョンを追加していく
         else:
             # バージョンが見つからない場合のデフォルト

--- a/py_nifcloud/nifcloud_client.py
+++ b/py_nifcloud/nifcloud_client.py
@@ -1,7 +1,7 @@
 # -*- encoding:utf-8 -*-
 from botocore.credentials import Credentials
 from botocore.awsrequest import AWSRequest
-from py_nifcloud.auth import NifCloudSigV2Auth, NifCloudSigV0Auth
+from py_nifcloud.auth import NifCloudSigV2Auth, NifCloudSigV1Auth, NifCloudSigV0Auth
 import os
 import yaml
 import requests
@@ -96,6 +96,8 @@ class NifCloudClient(object):
         signature_version = self._get_signature_version(request)
         if signature_version == "2":
             NifCloudSigV2Auth(self.CREDENTIALS).add_auth(request)
+        elif signature_version == "1":
+            NifCloudSigV1Auth(self.CREDENTIALS).add_auth(request)
         elif signature_version == "0":
             NifCloudSigV0Auth(self.CREDENTIALS).add_auth(request)
             # TODO: 他のバージョンを追加していく

--- a/tests/test_nifcloud_auth.py
+++ b/tests/test_nifcloud_auth.py
@@ -4,7 +4,7 @@ import copy
 import freezegun
 from botocore.credentials import Credentials
 from botocore.awsrequest import AWSRequest
-from py_nifcloud.auth import NifCloudSigV2Auth
+from py_nifcloud.auth import NifCloudSigV2Auth, NifCloudSigV0Auth
 
 
 @freezegun.freeze_time('2018-01-01 00:00:00')
@@ -47,4 +47,47 @@ class TestNifCloudSigV2Auth(unittest.TestCase):
                              "SignatureMethod": "HmacSHA256",
                              "Timestamp": "2018-01-01T00:00:00Z",
                              "Signature": "CVQW+ZFrPKunsmCsa7nILBiIH24nCR9kA9K31VWkzDU="
+                         })
+
+
+@freezegun.freeze_time('2018-01-01 00:00:00')
+class TestNifCloudSigV0Auth(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # ダミーの認証情報
+        cls.ACCESS_KEY_ID = "dummy_access_key_id"
+        cls.SECRET_ACCESS_KEY = "dummy_secret_access_key"
+
+        cls.endpoint_url = "https://computing.jp-east-1.api.cloud.nifty.com/api"
+        cls.params = {
+            "Action": "DescribeRegions",
+        }
+
+        # 認証情報を生成
+        cls.CREDENTIALS = Credentials(cls.ACCESS_KEY_ID, cls.SECRET_ACCESS_KEY)
+
+        cls.request = AWSRequest(method="GET", url=cls.endpoint_url, data=cls.params, headers={})
+
+        sut = NifCloudSigV0Auth(credentials=cls.CREDENTIALS)
+
+        # request情報更新
+        sut.add_auth(cls.request)
+
+    def test_add_auth_url(self):
+        self.assertEqual(self.request.url, self.endpoint_url)
+
+    def test_add_auth_data_action(self):
+        self.assertEqual(self.request.data["Action"], self.params["Action"])
+
+    def test_add_auth_data_auth_params(self):
+        # 認証パラメータのみ取り出し
+        auth_params = copy.deepcopy(self.request.data)
+        del auth_params["Action"]
+        self.assertEqual(auth_params,
+                         {
+                             "AccessKeyId": "dummy_access_key_id",
+                             "SignatureVersion": "0",
+                             "SignatureMethod": "HmacSHA1",
+                             "Timestamp": "2018-01-01T00:00:00Z",
+                             "Signature": "KjdQ0pQy4I0M8eRE4Qpx9Qs58cs="
                          })

--- a/tests/test_nifcloud_auth.py
+++ b/tests/test_nifcloud_auth.py
@@ -1,0 +1,50 @@
+# -*- encoding:utf-8 -*-
+import unittest
+import copy
+import freezegun
+from botocore.credentials import Credentials
+from botocore.awsrequest import AWSRequest
+from py_nifcloud.auth import NifCloudSigV2Auth
+
+
+@freezegun.freeze_time('2018-01-01 00:00:00')
+class TestNifCloudSigV2Auth(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # ダミーの認証情報
+        cls.ACCESS_KEY_ID = "dummy_access_key_id"
+        cls.SECRET_ACCESS_KEY = "dummy_secret_access_key"
+
+        cls.endpoint_url = "https://computing.jp-east-1.api.cloud.nifty.com/api"
+        cls.params = {
+            "Action": "DescribeRegions",
+        }
+
+        # 認証情報を生成
+        cls.CREDENTIALS = Credentials(cls.ACCESS_KEY_ID, cls.SECRET_ACCESS_KEY)
+
+        cls.request = AWSRequest(method="GET", url=cls.endpoint_url, data=cls.params, headers={})
+
+        sut = NifCloudSigV2Auth(credentials=cls.CREDENTIALS)
+
+        # request情報更新
+        sut.add_auth(cls.request)
+
+    def test_add_auth_url(self):
+        self.assertEqual(self.request.url, self.endpoint_url)
+
+    def test_add_auth_data_action(self):
+        self.assertEqual(self.request.data["Action"], self.params["Action"])
+
+    def test_add_auth_data_auth_params(self):
+        # 認証パラメータのみ取り出し
+        auth_params = copy.deepcopy(self.request.data)
+        del auth_params["Action"]
+        self.assertEqual(auth_params,
+                         {
+                             "AccessKeyId": "dummy_access_key_id",
+                             "SignatureVersion": "2",
+                             "SignatureMethod": "HmacSHA256",
+                             "Timestamp": "2018-01-01T00:00:00Z",
+                             "Signature": "CVQW+ZFrPKunsmCsa7nILBiIH24nCR9kA9K31VWkzDU="
+                         })

--- a/tests/test_nifcloud_auth.py
+++ b/tests/test_nifcloud_auth.py
@@ -4,7 +4,7 @@ import copy
 import freezegun
 from botocore.credentials import Credentials
 from botocore.awsrequest import AWSRequest
-from py_nifcloud.auth import NifCloudSigV2Auth, NifCloudSigV0Auth
+from py_nifcloud.auth import NifCloudSigV2Auth, NifCloudSigV1Auth, NifCloudSigV0Auth
 
 
 @freezegun.freeze_time('2018-01-01 00:00:00')
@@ -47,6 +47,49 @@ class TestNifCloudSigV2Auth(unittest.TestCase):
                              "SignatureMethod": "HmacSHA256",
                              "Timestamp": "2018-01-01T00:00:00Z",
                              "Signature": "CVQW+ZFrPKunsmCsa7nILBiIH24nCR9kA9K31VWkzDU="
+                         })
+
+
+@freezegun.freeze_time('2018-01-01 00:00:00')
+class TestNifCloudSigV1Auth(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # ダミーの認証情報
+        cls.ACCESS_KEY_ID = "dummy_access_key_id"
+        cls.SECRET_ACCESS_KEY = "dummy_secret_access_key"
+
+        cls.endpoint_url = "https://computing.jp-east-1.api.cloud.nifty.com/api"
+        cls.params = {
+            "Action": "DescribeRegions",
+        }
+
+        # 認証情報を生成
+        cls.CREDENTIALS = Credentials(cls.ACCESS_KEY_ID, cls.SECRET_ACCESS_KEY)
+
+        cls.request = AWSRequest(method="GET", url=cls.endpoint_url, data=cls.params, headers={})
+
+        sut = NifCloudSigV1Auth(credentials=cls.CREDENTIALS)
+
+        # request情報更新
+        sut.add_auth(cls.request)
+
+    def test_add_auth_url(self):
+        self.assertEqual(self.request.url, self.endpoint_url)
+
+    def test_add_auth_data_action(self):
+        self.assertEqual(self.request.data["Action"], self.params["Action"])
+
+    def test_add_auth_data_auth_params(self):
+        # 認証パラメータのみ取り出し
+        auth_params = copy.deepcopy(self.request.data)
+        del auth_params["Action"]
+        self.assertEqual(auth_params,
+                         {
+                             "AccessKeyId": "dummy_access_key_id",
+                             "SignatureVersion": "1",
+                             "SignatureMethod": "HmacSHA1",
+                             "Timestamp": "2018-01-01T00:00:00Z",
+                             "Signature": "GxXA64NHl5Xn6yMffVB8FSa0jlk="
                          })
 
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 関連URL

* https://github.com/o-hayato/py_nifcloud/issues/9
* https://github.com/o-hayato/py_nifcloud/issues/10

## 概要

* なぜこの変更をするのか： py_nifcloudでSignatureVersion=0, 1のAPIリクエストをさせたい
* 課題は何か：SignatureVersion=0, 1のSignature生成する仕組みがない・未実装
* これによってどう解決されるのか：py_nifcloudでSignatureVersion=0, 1のAPIリクエストができるようになる


## 影響範囲

* auth.py

## 技術的変更点概要

* auth.py
  * [x] NifCloudSigV0Auth
  * [x] NifCloudSigV1Auth
* nifcloud_client.py NifCloudClient
  * [x] queryにSignatureVersionが指定されている場合、そのシグネチャを生成(SignatureVersion=0,1対応)
* テスト追加
  * [x] test_auth.py：新規追加
    * NifCloudSigV2Auth
    * NifCloudSigV1Auth
    * NifCloudSigV0Auth


## このPRでのpy_nifcloudの変更点

```python
from py_nifcloud import ComputingClient
client = ComputingClient(region_name="jp-east-1")
```
を利用してリクエストする場合、computing APIは(defaultで)`SignatureVersion = 2`を使用してAPIリクエストをすることになってました。

この変更では`query`に渡された`SignatureVersion`の値より、該当するSignatureをリクエスト時に生成するようになってます。

**(リクエストをproxyingしてリクエストを生成している場合などに注意が必要になるかと思います)**
```python
# 自動的にSignatureVersion=2でSignatureを生成してAPIリクエスト(computingの場合)
params = {
    'Action': 'DescribeRegions',
}
response = client.request(method="GET", query=params)

# 明示的にSignatureVersion=2でSignatureを生成してAPIリクエスト
params = {
    'Action': 'DescribeRegions',
    'SignatureVersion ': '2',
}
response = client.request(method="GET", query=params)

# 明示的にSignatureVersion=0でSignatureを生成してAPIリクエスト
params = {
    'Action': 'DescribeRegions',
    'SignatureVersion ': '0',
}
response = client.request(method="GET", query=params)


# 明示的にSignatureVersion=1でSignatureを生成してAPIリクエスト
params = {
    'Action': 'DescribeRegions',
    'SignatureVersion ': '1',
}
response = client.request(method="GET", query=params)
```


## マイグレーション

* マイグレーションが必要なし

## テスト結果とテスト項目

* [x] tests/test_auth.py
* [x] tests/test_computing_client.py
* [x] tests/test_nifcloud_client.py
